### PR TITLE
read a token from file when exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following are optional configuration parameters supported in the `options` h
 
 `address`: The address of the Vault server, also read as ENV["VAULT_ADDR"]
 
-`token`: The token to authenticate with Vault, also read as ENV["VAULT_TOKEN"]
+`token`: The token to authenticate with Vault, also read as ENV["VAULT_TOKEN"] or a full path to the file with the token
 
 `:confine_to_keys: ` : Only use this backend if the key matches one of the regexes in the array
 

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -90,7 +90,13 @@ Puppet::Functions.create_function(:hiera_vault) do
     begin
       @@vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?
-        config.token = options['token'] unless options['token'].nil?
+        if not options['token'].nil?
+          if options['token'].start_with?('/') and File.exist?(options['token'])
+            config.token = File.read(options['token']).strip.chomp
+          else
+            config.token = options['token']
+          end
+        end
         config.ssl_pem_file = options['ssl_pem_file'] unless options['ssl_pem_file'].nil?
         config.ssl_verify = options['ssl_verify'] unless options['ssl_verify'].nil?
         config.ssl_ca_cert = options['ssl_ca_cert'] if config.respond_to? :ssl_ca_cert


### PR DESCRIPTION
I can't get _ENV["VAULT_TOKEN"]_ working and I haven't found any other secure way how to store a vault token than to specify a full path to the file with the token.

Example:
```yaml
  token: /etc/vault_token
```