### PR TITLE
Updating README to reflect kv v1 engine compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a back end function for Hiera 5 that allows lookup to be sourced from Ha
 
 ### Compatibility
 
-* This moduel is only compatible with Hiera 5 (ships with Puppet 4.9+)
+* This moduel is only compatible with Hiera 5 (ships with Puppet 4.9+) and Vault KV engine version 1
 
 ### Requirements
 


### PR DESCRIPTION
KV engine in Vault 1.0.0 is 2 by default causing the module to report:
```Function lookup() did not find a value for any of the names ['key', 'vault_test'] ```